### PR TITLE
Update status label if dropbox process not found

### DIFF
--- a/src/Services/Dropbox.vala
+++ b/src/Services/Dropbox.vala
@@ -102,7 +102,7 @@ public async string[] get_status () throws ThreadError {
 
         } catch (Error e) {
             print (e.message);
-            result[0] = "Dropbox process not found...";
+            result[0] = "Failed to get dropbox status";
         }
         
         Idle.add((owned)callback);

--- a/src/Services/Dropbox.vala
+++ b/src/Services/Dropbox.vala
@@ -102,6 +102,7 @@ public async string[] get_status () throws ThreadError {
 
         } catch (Error e) {
             print (e.message);
+            result[0] = "Dropbox process not found...";
         }
         
         Idle.add((owned)callback);


### PR DESCRIPTION
I'm honestly not too happy with using "Dropbox process not found". Perhaps a more generic status name would be better? Like "Dropbox process error"? Please do give suggestions.

With this PR:

![Screenshot from 2021-01-21 02-57-16](https://user-images.githubusercontent.com/31680656/105221737-80419080-5b94-11eb-93dc-0d252342d19a.png)